### PR TITLE
Potential fix for code scanning alert no. 18: Unused variable, import, function or class

### DIFF
--- a/rg_web/src/app/modules/core/api/v1/api/blog.service.ts
+++ b/rg_web/src/app/modules/core/api/v1/api/blog.service.ts
@@ -13,7 +13,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent, HttpParameterCodec, HttpContext 
         }       from '@angular/common/http';
-import { CustomHttpParameterCodec }                          from '../encoder';
+
 import { Observable }                                        from 'rxjs';
 
 // @ts-ignore


### PR DESCRIPTION
Potential fix for [https://github.com/axiom4/riccardogiannetto.com/security/code-scanning/18](https://github.com/axiom4/riccardogiannetto.com/security/code-scanning/18)

To fix the issue, the unused import `CustomHttpParameterCodec` should be removed from the file. This will improve code readability and maintainability by eliminating unnecessary clutter. The change involves deleting the line that imports `CustomHttpParameterCodec` from `../encoder`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
