### PR TITLE
Potential fix for code scanning alert no. 15: Unused variable, import, function or class

### DIFF
--- a/rg_web/src/app/modules/core/api/v1/api/portfolio.service.ts
+++ b/rg_web/src/app/modules/core/api/v1/api/portfolio.service.ts
@@ -10,8 +10,8 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent, HttpParameterCodec, HttpContext 
+import { HttpClient, HttpParams,
+         HttpResponse, HttpEvent, HttpContext 
         }       from '@angular/common/http';
 import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';


### PR DESCRIPTION
Potential fix for [https://github.com/axiom4/riccardogiannetto.com/security/code-scanning/15](https://github.com/axiom4/riccardogiannetto.com/security/code-scanning/15)

To fix the issue, the unused imports `HttpHeaders` and `HttpParameterCodec` should be removed from the import statement on line 13. This will eliminate unnecessary clutter and improve code readability without affecting functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
