### PR TITLE
Potential fix for code scanning alert no. 2: Unused variable, import, function or class

### DIFF
--- a/rg_web/src/app/modules/core/api/v1/api/portfolio.service.ts
+++ b/rg_web/src/app/modules/core/api/v1/api/portfolio.service.ts
@@ -26,7 +26,7 @@ import { PaginatedGalleryList } from '../model/paginatedGalleryList';
 import { PaginatedImageGalleryList } from '../model/paginatedImageGalleryList';
 
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
+import { BASE_PATH }                     from '../variables';
 import { Configuration }                                     from '../configuration';
 import { BaseService } from '../api.base.service';
 import {


### PR DESCRIPTION
Potential fix for [https://github.com/axiom4/riccardogiannetto.com/security/code-scanning/2](https://github.com/axiom4/riccardogiannetto.com/security/code-scanning/2)

The best way to fix this error is to remove `COLLECTION_FORMATS` from the import statement on line 29 in `rg_web/src/app/modules/core/api/v1/api/portfolio.service.ts`. This involves editing the import to only include the used symbol(s), which in this case is `BASE_PATH`. Make sure that only `BASE_PATH` is imported from `'../variables'`, leaving the rest of the code untouched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
